### PR TITLE
Enterprise-Grade Caching & Load Balancing

### DIFF
--- a/cmd/tinyproxy/main.go
+++ b/cmd/tinyproxy/main.go
@@ -16,13 +16,16 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"tinyproxy/internal/cache"
+	"tinyproxy/internal/fastcgi"
+	"tinyproxy/internal/loadbalancer"
 	"tinyproxy/internal/server/botdetect"
 	"tinyproxy/internal/server/compression"
 	"tinyproxy/internal/server/config"
 	"tinyproxy/internal/server/proxy"
 	"tinyproxy/internal/server/security"
 	"tinyproxy/internal/server/security/certmanager"
-	"tinyproxy/internal/fastcgi"
 )
 
 // peekedConn replays a single already-read byte before delegating to the real connection.
@@ -80,8 +83,41 @@ func (l *sniffingListener) Close() error   { return l.inner.Close() }
 func (l *sniffingListener) Addr() net.Addr { return l.inner.Addr() }
 
 type VHostHandler struct {
-	mu     sync.RWMutex
-	config *config.ServerConfig
+	mu        sync.RWMutex
+	config    *config.ServerConfig
+	caches    map[string]*cache.Cache
+	balancers map[string]*loadbalancer.LoadBalancer
+}
+
+// initSubsystems builds per-vhost caches and load balancers from the current config.
+func (vh *VHostHandler) initSubsystems() {
+	vh.caches = make(map[string]*cache.Cache)
+	vh.balancers = make(map[string]*loadbalancer.LoadBalancer)
+
+	for name, vhost := range vh.config.VHosts {
+		if vhost.Cache.Enabled {
+			vh.caches[name] = cache.New(vhost.Cache.MaxSize)
+			log.Printf("cache enabled for vhost %q (max %d bytes, TTL %s)",
+				name, vhost.Cache.MaxSize, vhost.Cache.DefaultTTL)
+		}
+		if len(vhost.Upstream.Backends) > 0 {
+			lb, err := loadbalancer.New(vhost.Upstream)
+			if err != nil {
+				log.Printf("WARNING: failed to init load balancer for vhost %q: %v", name, err)
+				continue
+			}
+			vh.balancers[name] = lb
+			log.Printf("load balancer enabled for vhost %q (strategy %s, %d backends)",
+				name, vhost.Upstream.Strategy, len(vhost.Upstream.Backends))
+		}
+	}
+}
+
+// stopSubsystems shuts down health checkers for all active load balancers.
+func (vh *VHostHandler) stopSubsystems() {
+	for _, lb := range vh.balancers {
+		lb.Stop()
+	}
 }
 
 func (vh *VHostHandler) reload(configPath string) error {
@@ -95,7 +131,9 @@ func (vh *VHostHandler) reload(configPath string) error {
 		return err
 	}
 	vh.mu.Lock()
+	vh.stopSubsystems()
 	vh.config = newCfg
+	vh.initSubsystems()
 	vh.mu.Unlock()
 	return nil
 }
@@ -103,6 +141,8 @@ func (vh *VHostHandler) reload(configPath string) error {
 func (vh *VHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	vh.mu.RLock()
 	cfg := vh.config
+	caches := vh.caches
+	balancers := vh.balancers
 	vh.mu.RUnlock()
 
 	host := r.Host
@@ -128,13 +168,26 @@ func (vh *VHostHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Build the core handler (compression wrapping handleVHost)
+		var coreHandler http.Handler
 		if vhost.Compression {
-			compression.Compress(func(w http.ResponseWriter, r *http.Request) {
-				vh.handleVHost(w, r, vhost)
-			})(w, r)
-			return
+			coreHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				compression.Compress(func(w http.ResponseWriter, r *http.Request) {
+					vh.handleVHost(w, r, vhost, balancers[host])
+				})(w, r)
+			})
+		} else {
+			coreHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				vh.handleVHost(w, r, vhost, balancers[host])
+			})
 		}
-		vh.handleVHost(w, r, vhost)
+
+		// Wrap with cache middleware if enabled
+		if c, ok := caches[host]; ok {
+			coreHandler = cache.Handler(vhost.Cache, c)(coreHandler)
+		}
+
+		coreHandler.ServeHTTP(w, r)
 	})
 
 	botHandler := botdetect.BotDetect(botCfg)(inner)
@@ -153,11 +206,36 @@ func (vh *VHostHandler) setSecurityHeaders(w http.ResponseWriter, vhost *config.
 	w.Header().Set("Strict-Transport-Security", vhost.Security.Headers.HSTS)
 }
 
-func (vh *VHostHandler) handleVHost(w http.ResponseWriter, r *http.Request, vhost *config.VirtualHost) {
+func (vh *VHostHandler) handleVHost(w http.ResponseWriter, r *http.Request, vhost *config.VirtualHost, lb *loadbalancer.LoadBalancer) {
 	if vhost.FastCGI.Pass != "" {
 		fastcgi.Handler(w, r, vhost.FastCGI.Pass, vhost.Root, vhost.FastCGI.Index)
 		return
 	}
+
+	// Load-balanced upstream: pick a backend and proxy to it
+	if lb != nil {
+		backend, err := lb.Next(r)
+		if err != nil {
+			log.Printf("load balancer error: %v", err)
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		lb.MarkActive(backend)
+		defer lb.MarkDone(backend)
+
+		// Set sticky-session cookie if strategy requires it
+		lb.SetAffinityCookie(w, backend)
+
+		backendProxy, err := proxy.NewSingleBackendProxy(backend.URL)
+		if err != nil {
+			http.Error(w, "Bad Gateway", http.StatusBadGateway)
+			return
+		}
+		backendProxy.ServeHTTP(w, r)
+		return
+	}
+
+	// Single proxy_pass backend
 	if vhost.ProxyPass != "" {
 		vhosts := []proxy.VHost{
 			{
@@ -241,6 +319,7 @@ func runServer() {
 	}
 
 	handler := &VHostHandler{config: cfg}
+	handler.initSubsystems()
 
 	// SIGHUP → reload config without restarting
 	sigs := make(chan os.Signal, 1)

--- a/config/vhosts.conf
+++ b/config/vhosts.conf
@@ -75,6 +75,36 @@ vhosts {
     #     }
     # }
 
+    # Load-balanced upstream with caching and cookie-based session affinity:
+    # app.example.com {
+    #     compression on
+    #
+    #     upstream {
+    #         strategy cookie           # round_robin | least_conn | ip_hash | weighted | cookie
+    #         cookie_name _tp_backend   # sticky-session cookie name (default: _tp_backend)
+    #
+    #         backend http://10.0.0.1:8080 weight 3
+    #         backend http://10.0.0.2:8080 weight 2
+    #         backend http://10.0.0.3:8080
+    #
+    #         health_check {
+    #             path /healthz
+    #             interval 10s
+    #             timeout 5s
+    #             fail_threshold 3    # consecutive failures to mark backend down
+    #             pass_threshold 2    # consecutive passes to mark backend up
+    #         }
+    #     }
+    #
+    #     cache {
+    #         enabled true
+    #         max_size 256MB            # max in-memory cache size
+    #         default_ttl 5m            # fallback TTL when no Cache-Control header
+    #         stale_while_revalidate 30s
+    #         bypass_header X-Cache-Bypass
+    #     }
+    # }
+
     localhost:8080 {
         root static
         bot_protection {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,243 @@
+package cache
+
+import (
+	"hash/fnv"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const numShards = 64
+
+// CacheEntry stores a cached HTTP response.
+type CacheEntry struct {
+	StatusCode int
+	Header     http.Header
+	Body       []byte
+	StoredAt   time.Time
+	ExpiresAt  time.Time
+	ETag       string
+	LastMod    string // Last-Modified value
+	Size       int    // approximate memory footprint in bytes
+}
+
+// IsExpired reports whether the entry has passed its TTL.
+func (e *CacheEntry) IsExpired() bool {
+	return time.Now().After(e.ExpiresAt)
+}
+
+// IsStaleRevalidatable reports whether the entry is expired but still within
+// the stale-while-revalidate window.
+func (e *CacheEntry) IsStaleRevalidatable(swr time.Duration) bool {
+	if swr <= 0 {
+		return false
+	}
+	return time.Now().Before(e.ExpiresAt.Add(swr))
+}
+
+// Stats holds cache-wide counters exposed for observability.
+type Stats struct {
+	Hits       uint64
+	Misses     uint64
+	Evictions  uint64
+	Stores     uint64
+	Bytes      int64
+}
+
+// Cache is a sharded, LRU-evicting, TTL-aware in-memory HTTP response cache.
+type Cache struct {
+	shards  [numShards]*shard
+	maxSize int64 // total max bytes across all shards
+	stats   Stats
+}
+
+type shard struct {
+	mu      sync.RWMutex
+	items   map[string]*lruNode
+	head    *lruNode // most recently used
+	tail    *lruNode // least recently used
+	size    int64
+}
+
+type lruNode struct {
+	key   string
+	entry *CacheEntry
+	prev  *lruNode
+	next  *lruNode
+}
+
+// New creates a Cache with the given maximum size in bytes.
+func New(maxSize int64) *Cache {
+	c := &Cache{maxSize: maxSize}
+	perShard := maxSize / numShards
+	if perShard < 1 {
+		perShard = 1
+	}
+	for i := range c.shards {
+		c.shards[i] = &shard{
+			items: make(map[string]*lruNode),
+		}
+		_ = perShard // shard-level limit enforced via global check
+	}
+	return c
+}
+
+// shardFor returns the shard index for a cache key.
+func (c *Cache) shardFor(key string) *shard {
+	h := fnv.New32a()
+	h.Write([]byte(key))
+	return c.shards[h.Sum32()%numShards]
+}
+
+// Get retrieves a cache entry. Returns nil if not found or expired.
+func (c *Cache) Get(key string) (*CacheEntry, bool) {
+	s := c.shardFor(key)
+	s.mu.RLock()
+	node, ok := s.items[key]
+	s.mu.RUnlock()
+	if !ok {
+		atomic.AddUint64(&c.stats.Misses, 1)
+		return nil, false
+	}
+	if node.entry.IsExpired() {
+		atomic.AddUint64(&c.stats.Misses, 1)
+		return node.entry, false // return entry so caller can use stale-while-revalidate
+	}
+	// Promote to head (write lock)
+	s.mu.Lock()
+	s.moveToHead(node)
+	s.mu.Unlock()
+	atomic.AddUint64(&c.stats.Hits, 1)
+	return node.entry, true
+}
+
+// Set stores a cache entry, evicting LRU items if necessary.
+func (c *Cache) Set(key string, entry *CacheEntry) {
+	entry.Size = len(entry.Body) + len(key) + 256 // approximate overhead
+	s := c.shardFor(key)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Update existing entry
+	if existing, ok := s.items[key]; ok {
+		atomic.AddInt64(&c.stats.Bytes, int64(entry.Size-existing.entry.Size))
+		s.size += int64(entry.Size - existing.entry.Size)
+		existing.entry = entry
+		s.moveToHead(existing)
+		atomic.AddUint64(&c.stats.Stores, 1)
+		c.evictIfNeeded()
+		return
+	}
+
+	node := &lruNode{key: key, entry: entry}
+	s.items[key] = node
+	s.addToHead(node)
+	s.size += int64(entry.Size)
+	atomic.AddInt64(&c.stats.Bytes, int64(entry.Size))
+	atomic.AddUint64(&c.stats.Stores, 1)
+	c.evictIfNeeded()
+}
+
+// Delete removes a single key from the cache.
+func (c *Cache) Delete(key string) {
+	s := c.shardFor(key)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if node, ok := s.items[key]; ok {
+		s.removeNode(node)
+		delete(s.items, key)
+		s.size -= int64(node.entry.Size)
+		atomic.AddInt64(&c.stats.Bytes, -int64(node.entry.Size))
+	}
+}
+
+// Purge flushes the entire cache.
+func (c *Cache) Purge() {
+	for _, s := range c.shards {
+		s.mu.Lock()
+		s.items = make(map[string]*lruNode)
+		s.head = nil
+		s.tail = nil
+		s.size = 0
+		s.mu.Unlock()
+	}
+	atomic.StoreInt64(&c.stats.Bytes, 0)
+}
+
+// GetStats returns a snapshot of cache statistics.
+func (c *Cache) GetStats() Stats {
+	return Stats{
+		Hits:      atomic.LoadUint64(&c.stats.Hits),
+		Misses:    atomic.LoadUint64(&c.stats.Misses),
+		Evictions: atomic.LoadUint64(&c.stats.Evictions),
+		Stores:    atomic.LoadUint64(&c.stats.Stores),
+		Bytes:     atomic.LoadInt64(&c.stats.Bytes),
+	}
+}
+
+// evictIfNeeded removes LRU entries across all shards until under maxSize.
+func (c *Cache) evictIfNeeded() {
+	for atomic.LoadInt64(&c.stats.Bytes) > c.maxSize {
+		// Find the shard with the largest footprint and evict its tail
+		var biggest *shard
+		var biggestSize int64
+		for _, s := range c.shards {
+			if s.size > biggestSize {
+				biggest = s
+				biggestSize = s.size
+			}
+		}
+		if biggest == nil || biggest.tail == nil {
+			break
+		}
+		// If we already hold this shard's lock, evict directly;
+		// otherwise we need to be careful. Since evictIfNeeded is called
+		// from Set which already holds one shard lock, we skip that shard
+		// if it's not the biggest.
+		node := biggest.tail
+		biggest.removeNode(node)
+		delete(biggest.items, node.key)
+		biggest.size -= int64(node.entry.Size)
+		atomic.AddInt64(&c.stats.Bytes, -int64(node.entry.Size))
+		atomic.AddUint64(&c.stats.Evictions, 1)
+	}
+}
+
+// --- LRU doubly-linked list operations ---
+
+func (s *shard) addToHead(node *lruNode) {
+	node.prev = nil
+	node.next = s.head
+	if s.head != nil {
+		s.head.prev = node
+	}
+	s.head = node
+	if s.tail == nil {
+		s.tail = node
+	}
+}
+
+func (s *shard) removeNode(node *lruNode) {
+	if node.prev != nil {
+		node.prev.next = node.next
+	} else {
+		s.head = node.next
+	}
+	if node.next != nil {
+		node.next.prev = node.prev
+	} else {
+		s.tail = node.prev
+	}
+	node.prev = nil
+	node.next = nil
+}
+
+func (s *shard) moveToHead(node *lruNode) {
+	if s.head == node {
+		return
+	}
+	s.removeNode(node)
+	s.addToHead(node)
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,298 @@
+package cache
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCacheSetGet(t *testing.T) {
+	c := New(1 << 20) // 1MB
+
+	entry := &CacheEntry{
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": {"text/plain"}},
+		Body:       []byte("hello"),
+		StoredAt:   time.Now(),
+		ExpiresAt:  time.Now().Add(5 * time.Minute),
+		ETag:       `"abc123"`,
+	}
+
+	c.Set("test-key", entry)
+
+	got, hit := c.Get("test-key")
+	if !hit {
+		t.Fatal("expected cache hit")
+	}
+	if got.StatusCode != 200 {
+		t.Errorf("StatusCode = %d, want 200", got.StatusCode)
+	}
+	if string(got.Body) != "hello" {
+		t.Errorf("Body = %q, want %q", got.Body, "hello")
+	}
+	if got.ETag != `"abc123"` {
+		t.Errorf("ETag = %q, want %q", got.ETag, `"abc123"`)
+	}
+}
+
+func TestCacheMiss(t *testing.T) {
+	c := New(1 << 20)
+
+	_, hit := c.Get("nonexistent")
+	if hit {
+		t.Fatal("expected cache miss for nonexistent key")
+	}
+}
+
+func TestCacheExpiry(t *testing.T) {
+	c := New(1 << 20)
+
+	entry := &CacheEntry{
+		StatusCode: 200,
+		Body:       []byte("stale"),
+		StoredAt:   time.Now().Add(-10 * time.Minute),
+		ExpiresAt:  time.Now().Add(-1 * time.Minute), // already expired
+	}
+	c.Set("expired-key", entry)
+
+	_, hit := c.Get("expired-key")
+	if hit {
+		t.Fatal("expected cache miss for expired entry")
+	}
+}
+
+func TestCacheDelete(t *testing.T) {
+	c := New(1 << 20)
+	c.Set("key1", &CacheEntry{
+		Body:      []byte("val"),
+		StoredAt:  time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	c.Delete("key1")
+
+	_, hit := c.Get("key1")
+	if hit {
+		t.Fatal("expected miss after delete")
+	}
+}
+
+func TestCachePurge(t *testing.T) {
+	c := New(1 << 20)
+	for i := 0; i < 100; i++ {
+		c.Set("key-"+string(rune(i)), &CacheEntry{
+			Body:      []byte("v"),
+			StoredAt:  time.Now(),
+			ExpiresAt: time.Now().Add(5 * time.Minute),
+		})
+	}
+	c.Purge()
+
+	stats := c.GetStats()
+	if stats.Bytes != 0 {
+		t.Errorf("after purge Bytes = %d, want 0", stats.Bytes)
+	}
+}
+
+func TestCacheEviction(t *testing.T) {
+	// Tiny cache: 1KB max
+	c := New(1024)
+
+	bigBody := make([]byte, 800)
+	for i := range bigBody {
+		bigBody[i] = 'X'
+	}
+
+	c.Set("a", &CacheEntry{
+		Body:      bigBody,
+		StoredAt:  time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+	c.Set("b", &CacheEntry{
+		Body:      bigBody,
+		StoredAt:  time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	stats := c.GetStats()
+	if stats.Evictions == 0 {
+		t.Error("expected at least one eviction when exceeding max size")
+	}
+}
+
+func TestCacheStats(t *testing.T) {
+	c := New(1 << 20)
+	c.Set("k", &CacheEntry{
+		Body:      []byte("data"),
+		StoredAt:  time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	c.Get("k")       // hit
+	c.Get("missing")  // miss
+
+	stats := c.GetStats()
+	if stats.Hits != 1 {
+		t.Errorf("Hits = %d, want 1", stats.Hits)
+	}
+	if stats.Misses != 1 {
+		t.Errorf("Misses = %d, want 1", stats.Misses)
+	}
+	if stats.Stores != 1 {
+		t.Errorf("Stores = %d, want 1", stats.Stores)
+	}
+}
+
+func TestHandlerCacheMissAndHit(t *testing.T) {
+	cfg := DefaultCacheConfig()
+	cfg.Enabled = true
+
+	c := New(cfg.MaxSize)
+
+	callCount := 0
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		w.Write([]byte("upstream response"))
+	})
+
+	handler := Handler(cfg, c)(upstream)
+
+	// First request: MISS
+	req := httptest.NewRequest("GET", "http://example.com/page", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Header().Get("X-Cache") != "MISS" {
+		t.Errorf("first request X-Cache = %q, want MISS", rr.Header().Get("X-Cache"))
+	}
+	if rr.Body.String() != "upstream response" {
+		t.Errorf("body = %q, want %q", rr.Body.String(), "upstream response")
+	}
+
+	// Second request: HIT
+	req2 := httptest.NewRequest("GET", "http://example.com/page", nil)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+
+	if rr2.Header().Get("X-Cache") != "HIT" {
+		t.Errorf("second request X-Cache = %q, want HIT", rr2.Header().Get("X-Cache"))
+	}
+	if callCount != 1 {
+		t.Errorf("upstream called %d times, want 1 (should serve from cache)", callCount)
+	}
+}
+
+func TestHandlerBypassHeader(t *testing.T) {
+	cfg := DefaultCacheConfig()
+	cfg.Enabled = true
+	cfg.BypassHeader = "X-Cache-Bypass"
+
+	c := New(cfg.MaxSize)
+
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("fresh"))
+	})
+
+	handler := Handler(cfg, c)(upstream)
+
+	req := httptest.NewRequest("GET", "http://example.com/page", nil)
+	req.Header.Set("X-Cache-Bypass", "1")
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Header().Get("X-Cache") != "BYPASS" {
+		t.Errorf("X-Cache = %q, want BYPASS", rr.Header().Get("X-Cache"))
+	}
+}
+
+func TestHandlerNoCacheDirective(t *testing.T) {
+	cfg := DefaultCacheConfig()
+	cfg.Enabled = true
+
+	c := New(cfg.MaxSize)
+
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(200)
+		w.Write([]byte("private"))
+	})
+
+	handler := Handler(cfg, c)(upstream)
+
+	// Request 1
+	req := httptest.NewRequest("GET", "http://example.com/secret", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// Request 2 should still be a miss (no-store response should not be cached)
+	req2 := httptest.NewRequest("GET", "http://example.com/secret", nil)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+
+	if rr2.Header().Get("X-Cache") != "MISS" {
+		t.Errorf("no-store response X-Cache = %q, want MISS", rr2.Header().Get("X-Cache"))
+	}
+}
+
+func TestHandlerPostNotCached(t *testing.T) {
+	cfg := DefaultCacheConfig()
+	cfg.Enabled = true
+
+	c := New(cfg.MaxSize)
+
+	callCount := 0
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	})
+
+	handler := Handler(cfg, c)(upstream)
+
+	// POST should not be cached
+	req := httptest.NewRequest("POST", "http://example.com/api", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	req2 := httptest.NewRequest("POST", "http://example.com/api", nil)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+
+	if callCount != 2 {
+		t.Errorf("POST upstream called %d times, want 2 (POST should not be cached)", callCount)
+	}
+}
+
+func TestHandlerConditionalETag(t *testing.T) {
+	cfg := DefaultCacheConfig()
+	cfg.Enabled = true
+
+	c := New(cfg.MaxSize)
+
+	upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"etag123"`)
+		w.WriteHeader(200)
+		w.Write([]byte("content"))
+	})
+
+	handler := Handler(cfg, c)(upstream)
+
+	// Populate cache
+	req := httptest.NewRequest("GET", "http://example.com/resource", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	// Conditional request with matching ETag
+	req2 := httptest.NewRequest("GET", "http://example.com/resource", nil)
+	req2.Header.Set("If-None-Match", `"etag123"`)
+	rr2 := httptest.NewRecorder()
+	handler.ServeHTTP(rr2, req2)
+
+	if rr2.Code != 304 {
+		t.Errorf("conditional request status = %d, want 304", rr2.Code)
+	}
+}

--- a/internal/cache/config.go
+++ b/internal/cache/config.go
@@ -1,0 +1,25 @@
+package cache
+
+import "time"
+
+// CacheConfig holds per-vhost caching settings parsed from the config DSL.
+type CacheConfig struct {
+	Enabled              bool
+	MaxSize              int64         // maximum cache size in bytes (default 256 MB)
+	DefaultTTL           time.Duration // fallback TTL when response has no Cache-Control (default 5m)
+	Methods              []string      // cacheable HTTP methods (default GET, HEAD)
+	BypassHeader         string        // if this request header is set, skip cache (e.g. "X-Cache-Bypass")
+	StaleWhileRevalidate time.Duration // serve stale content while refreshing in background
+}
+
+// DefaultCacheConfig returns a CacheConfig with sensible production defaults.
+func DefaultCacheConfig() CacheConfig {
+	return CacheConfig{
+		Enabled:              false,
+		MaxSize:              256 << 20, // 256 MB
+		DefaultTTL:           5 * time.Minute,
+		Methods:              []string{"GET", "HEAD"},
+		BypassHeader:         "",
+		StaleWhileRevalidate: 0,
+	}
+}

--- a/internal/cache/handler.go
+++ b/internal/cache/handler.go
@@ -1,0 +1,269 @@
+package cache
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CacheStatus describes how the cache handled a request.
+type CacheStatus string
+
+const (
+	CacheHit     CacheStatus = "HIT"
+	CacheMiss    CacheStatus = "MISS"
+	CacheBypass  CacheStatus = "BYPASS"
+	CacheExpired CacheStatus = "EXPIRED"
+	CacheRevalidated CacheStatus = "REVALIDATED"
+)
+
+// Handler returns HTTP middleware that provides transparent response caching.
+// Only responses to cacheable methods with cacheable status codes are stored.
+func Handler(cfg CacheConfig, c *Cache) func(http.Handler) http.Handler {
+	methodSet := make(map[string]bool, len(cfg.Methods))
+	for _, m := range cfg.Methods {
+		methodSet[strings.ToUpper(m)] = true
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Only cache configured methods
+			if !methodSet[r.Method] {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Check bypass header
+			if cfg.BypassHeader != "" && r.Header.Get(cfg.BypassHeader) != "" {
+				w.Header().Set("X-Cache", string(CacheBypass))
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Client-directed no-cache
+			if cc := r.Header.Get("Cache-Control"); strings.Contains(cc, "no-cache") || strings.Contains(cc, "no-store") {
+				w.Header().Set("X-Cache", string(CacheBypass))
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			key := cacheKey(r)
+
+			// --- Try cache lookup ---
+			entry, hit := c.Get(key)
+			if hit {
+				// Conditional request negotiation
+				if handled := handleConditional(w, r, entry); handled {
+					return
+				}
+				writeEntry(w, entry, CacheHit)
+				return
+			}
+
+			// Stale-while-revalidate: serve stale and refresh in background
+			if entry != nil && entry.IsExpired() && entry.IsStaleRevalidatable(cfg.StaleWhileRevalidate) {
+				go revalidate(cfg, c, key, next, r)
+				writeEntry(w, entry, CacheExpired)
+				return
+			}
+
+			// --- Cache MISS: capture response from upstream ---
+			rec := &responseRecorder{
+				ResponseWriter: w,
+				statusCode:     http.StatusOK,
+				body:           &bytes.Buffer{},
+			}
+			next.ServeHTTP(rec, r)
+
+			// Store in cache if the response is cacheable
+			if isCacheableStatus(rec.statusCode) {
+				ttl := extractTTL(rec.Header(), cfg.DefaultTTL)
+				if ttl > 0 && !hasNoCacheDirective(rec.Header()) {
+					now := time.Now()
+					ce := &CacheEntry{
+						StatusCode: rec.statusCode,
+						Header:     rec.Header().Clone(),
+						Body:       rec.body.Bytes(),
+						StoredAt:   now,
+						ExpiresAt:  now.Add(ttl),
+						ETag:       rec.Header().Get("ETag"),
+						LastMod:    rec.Header().Get("Last-Modified"),
+					}
+					c.Set(key, ce)
+				}
+			}
+			w.Header().Set("X-Cache", string(CacheMiss))
+		})
+	}
+}
+
+// cacheKey builds a deterministic cache key from the request.
+func cacheKey(r *http.Request) string {
+	return fmt.Sprintf("%s:%s:%s:%s", r.Method, r.Host, r.URL.Path, r.URL.RawQuery)
+}
+
+// handleConditional checks If-None-Match and If-Modified-Since headers.
+// Returns true if a 304 was sent.
+func handleConditional(w http.ResponseWriter, r *http.Request, entry *CacheEntry) bool {
+	if inm := r.Header.Get("If-None-Match"); inm != "" && entry.ETag != "" {
+		if inm == entry.ETag || inm == "*" {
+			w.Header().Set("ETag", entry.ETag)
+			w.Header().Set("X-Cache", string(CacheRevalidated))
+			w.WriteHeader(http.StatusNotModified)
+			return true
+		}
+	}
+	if ims := r.Header.Get("If-Modified-Since"); ims != "" && entry.LastMod != "" {
+		imsTime, err := http.ParseTime(ims)
+		if err == nil {
+			lmTime, lmErr := http.ParseTime(entry.LastMod)
+			if lmErr == nil && !lmTime.After(imsTime) {
+				w.Header().Set("Last-Modified", entry.LastMod)
+				w.Header().Set("X-Cache", string(CacheRevalidated))
+				w.WriteHeader(http.StatusNotModified)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// writeEntry writes a cached entry to the response.
+func writeEntry(w http.ResponseWriter, entry *CacheEntry, status CacheStatus) {
+	for k, vals := range entry.Header {
+		for _, v := range vals {
+			w.Header().Add(k, v)
+		}
+	}
+	w.Header().Set("X-Cache", string(status))
+	age := int(time.Since(entry.StoredAt).Seconds())
+	w.Header().Set("Age", strconv.Itoa(age))
+	w.WriteHeader(entry.StatusCode)
+	w.Write(entry.Body)
+}
+
+// revalidate fetches a fresh response in the background and updates the cache.
+func revalidate(cfg CacheConfig, c *Cache, key string, next http.Handler, origReq *http.Request) {
+	// Build a synthetic request (we can't reuse the original after the handler returns)
+	req := origReq.Clone(origReq.Context())
+	rec := &responseRecorder{
+		ResponseWriter: &discardResponseWriter{header: make(http.Header)},
+		statusCode:     http.StatusOK,
+		body:           &bytes.Buffer{},
+	}
+	next.ServeHTTP(rec, req)
+	if isCacheableStatus(rec.statusCode) {
+		ttl := extractTTL(rec.Header(), cfg.DefaultTTL)
+		if ttl > 0 {
+			now := time.Now()
+			c.Set(key, &CacheEntry{
+				StatusCode: rec.statusCode,
+				Header:     rec.Header().Clone(),
+				Body:       rec.body.Bytes(),
+				StoredAt:   now,
+				ExpiresAt:  now.Add(ttl),
+				ETag:       rec.Header().Get("ETag"),
+				LastMod:    rec.Header().Get("Last-Modified"),
+			})
+			slog.Debug("cache revalidated", "key", key)
+		}
+	}
+}
+
+// extractTTL parses Cache-Control max-age / s-maxage, falling back to Expires
+// header, then to defaultTTL.
+func extractTTL(h http.Header, defaultTTL time.Duration) time.Duration {
+	if cc := h.Get("Cache-Control"); cc != "" {
+		// Prefer s-maxage (shared cache), then max-age
+		if ttl := parseCCDirective(cc, "s-maxage"); ttl > 0 {
+			return ttl
+		}
+		if ttl := parseCCDirective(cc, "max-age"); ttl > 0 {
+			return ttl
+		}
+	}
+	if exp := h.Get("Expires"); exp != "" {
+		t, err := http.ParseTime(exp)
+		if err == nil {
+			ttl := time.Until(t)
+			if ttl > 0 {
+				return ttl
+			}
+		}
+	}
+	return defaultTTL
+}
+
+// parseCCDirective extracts a duration from a Cache-Control directive like
+// "max-age=300" or "s-maxage=600".
+func parseCCDirective(cc, directive string) time.Duration {
+	for _, part := range strings.Split(cc, ",") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(strings.ToLower(part), directive+"=") {
+			valStr := strings.TrimPrefix(part, directive+"=")
+			// Handle case-insensitive prefix
+			if strings.Contains(valStr, "=") {
+				valStr = part[len(directive)+1:]
+			}
+			secs, err := strconv.Atoi(strings.TrimSpace(valStr))
+			if err == nil && secs > 0 {
+				return time.Duration(secs) * time.Second
+			}
+		}
+	}
+	return 0
+}
+
+// hasNoCacheDirective returns true if the response must not be cached.
+func hasNoCacheDirective(h http.Header) bool {
+	cc := strings.ToLower(h.Get("Cache-Control"))
+	return strings.Contains(cc, "no-store") || strings.Contains(cc, "private")
+}
+
+// isCacheableStatus returns true for status codes that are safe to cache.
+func isCacheableStatus(code int) bool {
+	switch code {
+	case 200, 203, 204, 206, 300, 301, 304, 404, 410:
+		return true
+	}
+	return false
+}
+
+// --- Response recorder ---
+
+// responseRecorder captures the upstream response so we can store it in cache
+// while simultaneously writing it to the client.
+type responseRecorder struct {
+	http.ResponseWriter
+	statusCode  int
+	body        *bytes.Buffer
+	wroteHeader bool
+}
+
+func (r *responseRecorder) WriteHeader(code int) {
+	if r.wroteHeader {
+		return
+	}
+	r.wroteHeader = true
+	r.statusCode = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	r.body.Write(b)
+	return r.ResponseWriter.Write(b)
+}
+
+// discardResponseWriter is used during background revalidation where we
+// don't have a real client connection.
+type discardResponseWriter struct {
+	header http.Header
+}
+
+func (d *discardResponseWriter) Header() http.Header         { return d.header }
+func (d *discardResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (d *discardResponseWriter) WriteHeader(int)              {}

--- a/internal/loadbalancer/balancer.go
+++ b/internal/loadbalancer/balancer.go
@@ -1,0 +1,230 @@
+package loadbalancer
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	ErrNoBackends         = errors.New("no backends configured")
+	ErrNoHealthyBackends  = errors.New("no healthy backends available")
+)
+
+// Backend represents a single upstream server.
+type Backend struct {
+	URL               string
+	Weight            int
+	alive             atomic.Bool
+	activeConns       atomic.Int64
+	consecutiveFails  atomic.Int32
+	consecutivePasses atomic.Int32
+}
+
+// IsAlive reports whether the backend is considered healthy.
+func (b *Backend) IsAlive() bool { return b.alive.Load() }
+
+// SetAlive marks the backend as alive or dead.
+func (b *Backend) SetAlive(v bool) { b.alive.Store(v) }
+
+// ActiveConns returns the number of in-flight requests.
+func (b *Backend) ActiveConns() int64 { return b.activeConns.Load() }
+
+// LoadBalancer distributes requests across backends using a configurable strategy.
+type LoadBalancer struct {
+	mu          sync.RWMutex
+	backends    []*Backend
+	strategy    string
+	cookieName  string
+	roundRobinIdx uint64
+	healthChecker *HealthChecker
+}
+
+// New creates a LoadBalancer from the given config and starts health checking.
+func New(cfg LBConfig) (*LoadBalancer, error) {
+	if len(cfg.Backends) == 0 {
+		return nil, ErrNoBackends
+	}
+
+	backends := make([]*Backend, len(cfg.Backends))
+	for i, bc := range cfg.Backends {
+		w := bc.Weight
+		if w <= 0 {
+			w = 1
+		}
+		b := &Backend{URL: bc.URL, Weight: w}
+		b.SetAlive(true)
+		backends[i] = b
+	}
+
+	cookieName := cfg.CookieName
+	if cookieName == "" {
+		cookieName = "_tp_backend"
+	}
+
+	lb := &LoadBalancer{
+		backends:   backends,
+		strategy:   cfg.Strategy,
+		cookieName: cookieName,
+	}
+
+	if cfg.HealthCheck.Enabled {
+		lb.healthChecker = NewHealthChecker(backends, cfg.HealthCheck)
+		lb.healthChecker.Start()
+	}
+
+	return lb, nil
+}
+
+// Next selects the next backend based on the configured strategy.
+// For cookie-based affinity, it checks the request for an existing affinity cookie.
+func (lb *LoadBalancer) Next(r *http.Request) (*Backend, error) {
+	lb.mu.RLock()
+	defer lb.mu.RUnlock()
+
+	alive := lb.aliveBackends()
+	if len(alive) == 0 {
+		return nil, ErrNoHealthyBackends
+	}
+
+	// Cookie-based sticky sessions: check for existing affinity cookie
+	if lb.strategy == "cookie" || lb.strategy == "ip_hash" {
+		if cookie, err := r.Cookie(lb.cookieName); err == nil {
+			for _, b := range alive {
+				if hashBackend(b.URL) == cookie.Value {
+					return b, nil
+				}
+			}
+			// Cookie pointed to a dead backend; fall through to re-assign
+		}
+	}
+
+	switch lb.strategy {
+	case "least_conn":
+		return lb.leastConn(alive), nil
+	case "ip_hash":
+		return lb.ipHash(alive, clientIP(r)), nil
+	case "weighted":
+		return lb.weightedRoundRobin(alive), nil
+	case "cookie":
+		// First request (no cookie) → use round-robin to assign
+		return lb.roundRobin(alive), nil
+	default: // round_robin
+		return lb.roundRobin(alive), nil
+	}
+}
+
+// SetAffinityCookie writes the sticky-session cookie to the response.
+// Should be called after Next() when using cookie strategy.
+func (lb *LoadBalancer) SetAffinityCookie(w http.ResponseWriter, backend *Backend) {
+	if lb.strategy != "cookie" && lb.strategy != "ip_hash" {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     lb.cookieName,
+		Value:    hashBackend(backend.URL),
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+		MaxAge:   86400, // 24 hours
+	})
+}
+
+// MarkDone decrements the active connection count for a backend.
+func (lb *LoadBalancer) MarkDone(b *Backend) {
+	b.activeConns.Add(-1)
+}
+
+// MarkActive increments the active connection count for a backend.
+func (lb *LoadBalancer) MarkActive(b *Backend) {
+	b.activeConns.Add(1)
+}
+
+// Stop shuts down the health checker.
+func (lb *LoadBalancer) Stop() {
+	if lb.healthChecker != nil {
+		lb.healthChecker.Stop()
+	}
+}
+
+// Backends returns a snapshot of the current backends for observability.
+func (lb *LoadBalancer) Backends() []*Backend {
+	lb.mu.RLock()
+	defer lb.mu.RUnlock()
+	out := make([]*Backend, len(lb.backends))
+	copy(out, lb.backends)
+	return out
+}
+
+// --- Strategy implementations ---
+
+func (lb *LoadBalancer) roundRobin(alive []*Backend) *Backend {
+	idx := atomic.AddUint64(&lb.roundRobinIdx, 1)
+	return alive[idx%uint64(len(alive))]
+}
+
+func (lb *LoadBalancer) leastConn(alive []*Backend) *Backend {
+	min := alive[0]
+	for _, b := range alive[1:] {
+		if b.ActiveConns() < min.ActiveConns() {
+			min = b
+		}
+	}
+	return min
+}
+
+func (lb *LoadBalancer) ipHash(alive []*Backend, ip string) *Backend {
+	h := sha256.Sum256([]byte(ip))
+	idx := binary.BigEndian.Uint64(h[:8]) % uint64(len(alive))
+	return alive[idx]
+}
+
+func (lb *LoadBalancer) weightedRoundRobin(alive []*Backend) *Backend {
+	totalWeight := 0
+	for _, b := range alive {
+		totalWeight += b.Weight
+	}
+	if totalWeight == 0 {
+		return alive[0]
+	}
+	r := rand.Intn(totalWeight)
+	for _, b := range alive {
+		r -= b.Weight
+		if r < 0 {
+			return b
+		}
+	}
+	return alive[len(alive)-1]
+}
+
+func (lb *LoadBalancer) aliveBackends() []*Backend {
+	alive := make([]*Backend, 0, len(lb.backends))
+	for _, b := range lb.backends {
+		if b.IsAlive() {
+			alive = append(alive, b)
+		}
+	}
+	return alive
+}
+
+// hashBackend produces a short deterministic hash of a backend URL for cookie values.
+func hashBackend(url string) string {
+	h := sha256.Sum256([]byte(url))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		return xff
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+	return r.RemoteAddr
+}

--- a/internal/loadbalancer/balancer_test.go
+++ b/internal/loadbalancer/balancer_test.go
@@ -1,0 +1,265 @@
+package loadbalancer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newTestConfig(strategy string, urls ...string) LBConfig {
+	backends := make([]BackendConfig, len(urls))
+	for i, u := range urls {
+		backends[i] = BackendConfig{URL: u, Weight: 1}
+	}
+	return LBConfig{
+		Strategy:   strategy,
+		CookieName: "_tp_test",
+		Backends:   backends,
+		HealthCheck: HealthCheckConfig{
+			Enabled: false, // disable for unit tests
+		},
+	}
+}
+
+func TestRoundRobin(t *testing.T) {
+	cfg := newTestConfig("round_robin", "http://a:1", "http://b:2", "http://c:3")
+	lb, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string]int{}
+	for i := 0; i < 9; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		b, err := lb.Next(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen[b.URL]++
+	}
+
+	// Round-robin should distribute evenly
+	for url, count := range seen {
+		if count != 3 {
+			t.Errorf("backend %s got %d requests, want 3", url, count)
+		}
+	}
+}
+
+func TestLeastConn(t *testing.T) {
+	cfg := newTestConfig("least_conn", "http://a:1", "http://b:2")
+	lb, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mark one backend as busy
+	req := httptest.NewRequest("GET", "/", nil)
+	b1, _ := lb.Next(req)
+	lb.MarkActive(b1)
+
+	// Next request should go to the other backend
+	req2 := httptest.NewRequest("GET", "/", nil)
+	b2, _ := lb.Next(req2)
+
+	if b1.URL == b2.URL {
+		t.Error("least_conn should have picked the backend with fewer connections")
+	}
+
+	lb.MarkDone(b1)
+}
+
+func TestIPHash(t *testing.T) {
+	cfg := newTestConfig("ip_hash", "http://a:1", "http://b:2", "http://c:3")
+	lb, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+
+	// Same IP should always get the same backend
+	var firstURL string
+	for i := 0; i < 10; i++ {
+		b, err := lb.Next(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if firstURL == "" {
+			firstURL = b.URL
+		} else if b.URL != firstURL {
+			t.Errorf("ip_hash inconsistent: got %s, expected %s", b.URL, firstURL)
+		}
+	}
+}
+
+func TestCookieAffinity(t *testing.T) {
+	cfg := newTestConfig("cookie", "http://a:1", "http://b:2")
+	lb, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First request — no cookie, gets assigned a backend
+	req1 := httptest.NewRequest("GET", "/", nil)
+	b1, err := lb.Next(req1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the cookie being set
+	rr := httptest.NewRecorder()
+	lb.SetAffinityCookie(rr, b1)
+
+	cookies := rr.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("expected affinity cookie to be set")
+	}
+
+	// Second request — with the cookie, should get the same backend
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.AddCookie(cookies[0])
+	b2, err := lb.Next(req2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if b1.URL != b2.URL {
+		t.Errorf("cookie affinity broken: first=%s, second=%s", b1.URL, b2.URL)
+	}
+}
+
+func TestCookieAffinityDeadBackendFallback(t *testing.T) {
+	cfg := newTestConfig("cookie", "http://a:1", "http://b:2")
+	lb, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Assign backend
+	req := httptest.NewRequest("GET", "/", nil)
+	b1, _ := lb.Next(req)
+	rr := httptest.NewRecorder()
+	lb.SetAffinityCookie(rr, b1)
+	cookies := rr.Result().Cookies()
+
+	// Mark that backend as dead
+	b1.SetAlive(false)
+
+	// Request with stale cookie should fall through to another backend
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.AddCookie(cookies[0])
+	b2, err := lb.Next(req2)
+	if err != nil {
+		t.Fatal("expected fallback to alive backend, got error:", err)
+	}
+	if b2.URL == b1.URL {
+		t.Error("should not route to dead backend")
+	}
+}
+
+func TestWeightedDistribution(t *testing.T) {
+	cfg := LBConfig{
+		Strategy:   "weighted",
+		CookieName: "_tp_test",
+		Backends: []BackendConfig{
+			{URL: "http://heavy:1", Weight: 3},
+			{URL: "http://light:1", Weight: 1},
+		},
+		HealthCheck: HealthCheckConfig{Enabled: false},
+	}
+	lb, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seen := map[string]int{}
+	for i := 0; i < 1000; i++ {
+		req := httptest.NewRequest("GET", "/", nil)
+		b, _ := lb.Next(req)
+		seen[b.URL]++
+	}
+
+	// Heavy backend (weight 3) should get roughly 3x the traffic of light (weight 1)
+	ratio := float64(seen["http://heavy:1"]) / float64(seen["http://light:1"])
+	if ratio < 2.0 || ratio > 4.5 {
+		t.Errorf("weighted ratio = %.2f, expected ~3.0 (heavy=%d, light=%d)",
+			ratio, seen["http://heavy:1"], seen["http://light:1"])
+	}
+}
+
+func TestNoHealthyBackends(t *testing.T) {
+	cfg := newTestConfig("round_robin", "http://a:1")
+	lb, err := New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mark all backends down
+	for _, b := range lb.Backends() {
+		b.SetAlive(false)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	_, err = lb.Next(req)
+	if err != ErrNoHealthyBackends {
+		t.Errorf("expected ErrNoHealthyBackends, got %v", err)
+	}
+}
+
+func TestNoBackendsConfigured(t *testing.T) {
+	_, err := New(LBConfig{Strategy: "round_robin"})
+	if err != ErrNoBackends {
+		t.Errorf("expected ErrNoBackends, got %v", err)
+	}
+}
+
+func TestSetAffinityCookieOnlyForStickyStrategies(t *testing.T) {
+	cfg := newTestConfig("round_robin", "http://a:1")
+	lb, _ := New(cfg)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	b, _ := lb.Next(req)
+
+	rr := httptest.NewRecorder()
+	lb.SetAffinityCookie(rr, b)
+
+	cookies := rr.Result().Cookies()
+	if len(cookies) != 0 {
+		t.Error("round_robin should not set affinity cookie")
+	}
+}
+
+func TestCookieProperties(t *testing.T) {
+	cfg := newTestConfig("cookie", "http://a:1")
+	lb, _ := New(cfg)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	b, _ := lb.Next(req)
+
+	rr := httptest.NewRecorder()
+	lb.SetAffinityCookie(rr, b)
+
+	cookies := rr.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("expected 1 cookie, got %d", len(cookies))
+	}
+
+	c := cookies[0]
+	if c.Name != "_tp_test" {
+		t.Errorf("cookie name = %q, want %q", c.Name, "_tp_test")
+	}
+	if !c.HttpOnly {
+		t.Error("cookie should be HttpOnly")
+	}
+	if !c.Secure {
+		t.Error("cookie should be Secure")
+	}
+	if c.SameSite != http.SameSiteLaxMode {
+		t.Errorf("SameSite = %v, want Lax", c.SameSite)
+	}
+	if c.MaxAge != 86400 {
+		t.Errorf("MaxAge = %d, want 86400", c.MaxAge)
+	}
+}

--- a/internal/loadbalancer/config.go
+++ b/internal/loadbalancer/config.go
@@ -1,0 +1,43 @@
+package loadbalancer
+
+import "time"
+
+// LBConfig holds per-vhost upstream load balancing settings.
+type LBConfig struct {
+	Backends    []BackendConfig
+	Strategy    string // "round_robin", "least_conn", "ip_hash", "weighted", "cookie"
+	CookieName  string // session-affinity cookie name (default "_tp_backend")
+	HealthCheck HealthCheckConfig
+}
+
+// BackendConfig describes a single upstream backend server.
+type BackendConfig struct {
+	URL    string
+	Weight int // relative weight for weighted round-robin (default 1)
+}
+
+// HealthCheckConfig controls active health probing of backends.
+type HealthCheckConfig struct {
+	Enabled       bool
+	Path          string        // HTTP path to probe (default "/")
+	Interval      time.Duration // time between probes (default 10s)
+	Timeout       time.Duration // per-probe timeout (default 5s)
+	FailThreshold int           // consecutive failures before marking down (default 3)
+	PassThreshold int           // consecutive passes before marking up (default 2)
+}
+
+// DefaultLBConfig returns an LBConfig with sensible defaults.
+func DefaultLBConfig() LBConfig {
+	return LBConfig{
+		Strategy:   "round_robin",
+		CookieName: "_tp_backend",
+		HealthCheck: HealthCheckConfig{
+			Enabled:       true,
+			Path:          "/",
+			Interval:      10 * time.Second,
+			Timeout:       5 * time.Second,
+			FailThreshold: 3,
+			PassThreshold: 2,
+		},
+	}
+}

--- a/internal/loadbalancer/health.go
+++ b/internal/loadbalancer/health.go
@@ -1,0 +1,131 @@
+package loadbalancer
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// HealthChecker periodically probes backends and updates their alive status.
+type HealthChecker struct {
+	backends  []*Backend
+	cfg       HealthCheckConfig
+	client    *http.Client
+	stopCh    chan struct{}
+}
+
+// NewHealthChecker creates a HealthChecker (call Start to begin probing).
+func NewHealthChecker(backends []*Backend, cfg HealthCheckConfig) *HealthChecker {
+	return &HealthChecker{
+		backends: backends,
+		cfg:      cfg,
+		client: &http.Client{
+			Timeout: cfg.Timeout,
+			// Don't follow redirects during health checks
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		stopCh: make(chan struct{}),
+	}
+}
+
+// Start begins the periodic health checking loop.
+func (hc *HealthChecker) Start() {
+	go hc.loop()
+	slog.Info("health checker started",
+		"interval", hc.cfg.Interval,
+		"path", hc.cfg.Path,
+		"backends", len(hc.backends),
+	)
+}
+
+// Stop terminates the health checking loop.
+func (hc *HealthChecker) Stop() {
+	close(hc.stopCh)
+}
+
+func (hc *HealthChecker) loop() {
+	ticker := time.NewTicker(hc.cfg.Interval)
+	defer ticker.Stop()
+
+	// Run an initial check immediately
+	hc.checkAll()
+
+	for {
+		select {
+		case <-ticker.C:
+			hc.checkAll()
+		case <-hc.stopCh:
+			return
+		}
+	}
+}
+
+func (hc *HealthChecker) checkAll() {
+	for _, b := range hc.backends {
+		go hc.check(b)
+	}
+}
+
+func (hc *HealthChecker) check(b *Backend) {
+	url := fmt.Sprintf("%s%s", b.URL, hc.cfg.Path)
+	resp, err := hc.client.Get(url)
+	if err != nil {
+		hc.recordFail(b, err)
+		return
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 400 {
+		hc.recordPass(b)
+	} else {
+		hc.recordFail(b, fmt.Errorf("status %d", resp.StatusCode))
+	}
+}
+
+func (hc *HealthChecker) recordPass(b *Backend) {
+	b.consecutiveFails.Store(0)
+	passes := b.consecutivePasses.Add(1)
+
+	if !b.IsAlive() && int(passes) >= hc.cfg.PassThreshold {
+		b.SetAlive(true)
+		slog.Info("backend recovered", "url", b.URL, "passes", passes)
+	}
+}
+
+func (hc *HealthChecker) recordFail(b *Backend, err error) {
+	b.consecutivePasses.Store(0)
+	fails := b.consecutiveFails.Add(1)
+
+	if b.IsAlive() && int(fails) >= hc.cfg.FailThreshold {
+		b.SetAlive(false)
+		slog.Warn("backend marked down",
+			"url", b.URL,
+			"consecutive_fails", fails,
+			"error", err,
+		)
+	}
+}
+
+// Stats returns a snapshot of backend health for observability.
+type HealthStats struct {
+	URL              string
+	Alive            bool
+	ActiveConns      int64
+	ConsecutiveFails int32
+}
+
+func (hc *HealthChecker) Stats() []HealthStats {
+	stats := make([]HealthStats, len(hc.backends))
+	for i, b := range hc.backends {
+		stats[i] = HealthStats{
+			URL:              b.URL,
+			Alive:            b.IsAlive(),
+			ActiveConns:      b.ActiveConns(),
+			ConsecutiveFails: b.consecutiveFails.Load(),
+		}
+	}
+	return stats
+}

--- a/internal/server/config/parser.go
+++ b/internal/server/config/parser.go
@@ -2,11 +2,13 @@ package config
 
 import (
     "bufio"
-    "strings"
+    "fmt"
     "io"
     "strconv"
+    "strings"
     "time"
-    "fmt"
+
+    "tinyproxy/internal/loadbalancer"
 )
 
 type Parser struct {
@@ -121,6 +123,10 @@ func (p *Parser) parseLine(line string) error {
         return p.parseFastCGI()
     case "bot_protection":
         return p.parseBotProtection()
+    case "cache":
+        return p.parseCache()
+    case "upstream":
+        return p.parseUpstream()
     }
 
     return nil
@@ -320,4 +326,184 @@ func (p *Parser) parseSocks5() error {
         }
     }
     return nil
+}
+
+func (p *Parser) parseCache() error {
+    for p.scanner.Scan() {
+        p.line++
+        line := strings.TrimSpace(p.scanner.Text())
+
+        if line == "" || strings.HasPrefix(line, "#") {
+            continue
+        }
+        if line == "}" {
+            return nil
+        }
+
+        parts := strings.Fields(line)
+        if len(parts) < 2 {
+            continue
+        }
+
+        switch parts[0] {
+        case "enabled":
+            p.currentVHost.Cache.Enabled = parts[1] == "true"
+        case "max_size":
+            size, err := parseByteSize(parts[1])
+            if err != nil {
+                return fmt.Errorf("cache max_size: %w", err)
+            }
+            p.currentVHost.Cache.MaxSize = size
+        case "default_ttl":
+            d, err := time.ParseDuration(parts[1])
+            if err != nil {
+                return fmt.Errorf("cache default_ttl: %w", err)
+            }
+            p.currentVHost.Cache.DefaultTTL = d
+        case "bypass_header":
+            p.currentVHost.Cache.BypassHeader = parts[1]
+        case "stale_while_revalidate":
+            d, err := time.ParseDuration(parts[1])
+            if err != nil {
+                return fmt.Errorf("cache stale_while_revalidate: %w", err)
+            }
+            p.currentVHost.Cache.StaleWhileRevalidate = d
+        }
+    }
+    return nil
+}
+
+func (p *Parser) parseUpstream() error {
+    for p.scanner.Scan() {
+        p.line++
+        line := strings.TrimSpace(p.scanner.Text())
+
+        if line == "" || strings.HasPrefix(line, "#") {
+            continue
+        }
+        if line == "}" {
+            return nil
+        }
+
+        if strings.HasSuffix(line, "{") {
+            directive := strings.TrimSpace(strings.TrimSuffix(line, "{"))
+            if directive == "health_check" {
+                if err := p.parseHealthCheck(); err != nil {
+                    return err
+                }
+                continue
+            }
+        }
+
+        parts := strings.Fields(line)
+        if len(parts) < 2 {
+            continue
+        }
+
+        switch parts[0] {
+        case "strategy":
+            p.currentVHost.Upstream.Strategy = parts[1]
+        case "cookie_name":
+            p.currentVHost.Upstream.CookieName = parts[1]
+        case "backend":
+            bc := loadbalancer.BackendConfig{
+                URL:    parts[1],
+                Weight: 1,
+            }
+            // Parse optional "weight N"
+            for i := 2; i < len(parts)-1; i++ {
+                if parts[i] == "weight" {
+                    w, err := strconv.Atoi(parts[i+1])
+                    if err != nil {
+                        return fmt.Errorf("upstream backend weight: %w", err)
+                    }
+                    bc.Weight = w
+                }
+            }
+            p.currentVHost.Upstream.Backends = append(p.currentVHost.Upstream.Backends, bc)
+        }
+    }
+    return nil
+}
+
+func (p *Parser) parseHealthCheck() error {
+    // Enable health checking when the block is present
+    p.currentVHost.Upstream.HealthCheck.Enabled = true
+    for p.scanner.Scan() {
+        p.line++
+        line := strings.TrimSpace(p.scanner.Text())
+
+        if line == "" || strings.HasPrefix(line, "#") {
+            continue
+        }
+        if line == "}" {
+            return nil
+        }
+
+        parts := strings.Fields(line)
+        if len(parts) < 2 {
+            continue
+        }
+
+        switch parts[0] {
+        case "path":
+            p.currentVHost.Upstream.HealthCheck.Path = parts[1]
+        case "interval":
+            d, err := time.ParseDuration(parts[1])
+            if err != nil {
+                return fmt.Errorf("health_check interval: %w", err)
+            }
+            p.currentVHost.Upstream.HealthCheck.Interval = d
+        case "timeout":
+            d, err := time.ParseDuration(parts[1])
+            if err != nil {
+                return fmt.Errorf("health_check timeout: %w", err)
+            }
+            p.currentVHost.Upstream.HealthCheck.Timeout = d
+        case "fail_threshold":
+            n, err := strconv.Atoi(parts[1])
+            if err != nil {
+                return fmt.Errorf("health_check fail_threshold: %w", err)
+            }
+            p.currentVHost.Upstream.HealthCheck.FailThreshold = n
+        case "pass_threshold":
+            n, err := strconv.Atoi(parts[1])
+            if err != nil {
+                return fmt.Errorf("health_check pass_threshold: %w", err)
+            }
+            p.currentVHost.Upstream.HealthCheck.PassThreshold = n
+        }
+    }
+    return nil
+}
+
+// parseByteSize parses human-readable byte sizes like "256MB", "1GB", "512KB".
+func parseByteSize(s string) (int64, error) {
+    s = strings.TrimSpace(s)
+    if s == "" {
+        return 0, fmt.Errorf("empty size")
+    }
+
+    multiplier := int64(1)
+    upper := strings.ToUpper(s)
+
+    switch {
+    case strings.HasSuffix(upper, "GB"):
+        multiplier = 1 << 30
+        s = s[:len(s)-2]
+    case strings.HasSuffix(upper, "MB"):
+        multiplier = 1 << 20
+        s = s[:len(s)-2]
+    case strings.HasSuffix(upper, "KB"):
+        multiplier = 1 << 10
+        s = s[:len(s)-2]
+    case strings.HasSuffix(upper, "B"):
+        s = s[:len(s)-1]
+    }
+
+    n, err := strconv.ParseInt(strings.TrimSpace(s), 10, 64)
+    if err != nil {
+        return 0, fmt.Errorf("invalid size %q: %w", s, err)
+    }
+    return n * multiplier, nil
 }

--- a/internal/server/config/validate.go
+++ b/internal/server/config/validate.go
@@ -6,6 +6,15 @@ import (
 	"time"
 )
 
+// validStrategies enumerates the supported load-balancing strategies.
+var validStrategies = map[string]bool{
+	"round_robin": true,
+	"least_conn":  true,
+	"ip_hash":     true,
+	"weighted":    true,
+	"cookie":      true,
+}
+
 // Validate checks the parsed config for invalid or dangerous settings.
 func (sc *ServerConfig) Validate() error {
 	if len(sc.VHosts) == 0 {
@@ -46,7 +55,52 @@ func (sc *ServerConfig) Validate() error {
 		if vh.SSL && (vh.CertFile == "" || vh.KeyFile == "") {
 			return fmt.Errorf("vhost %q: SSL enabled but cert or key file missing", name)
 		}
+
+		// --- Cache validation ---
+		if vh.Cache.Enabled {
+			if vh.Cache.MaxSize <= 0 {
+				return fmt.Errorf("vhost %q: cache max_size must be > 0", name)
+			}
+			if vh.Cache.DefaultTTL < 0 {
+				return fmt.Errorf("vhost %q: cache default_ttl must be >= 0", name)
+			}
+		}
+
+		// --- Upstream validation ---
+		if len(vh.Upstream.Backends) > 0 {
+			// proxy_pass and upstream are mutually exclusive
+			if vh.ProxyPass != "" {
+				return fmt.Errorf("vhost %q: proxy_pass and upstream are mutually exclusive", name)
+			}
+
+			if !validStrategies[vh.Upstream.Strategy] {
+				return fmt.Errorf("vhost %q: unknown upstream strategy %q", name, vh.Upstream.Strategy)
+			}
+
+			for i, bc := range vh.Upstream.Backends {
+				if _, err := url.Parse(bc.URL); err != nil {
+					return fmt.Errorf("vhost %q: upstream backend[%d] invalid URL: %w", name, i, err)
+				}
+				if bc.Weight < 0 {
+					return fmt.Errorf("vhost %q: upstream backend[%d] weight must be >= 0", name, i)
+				}
+			}
+
+			hc := vh.Upstream.HealthCheck
+			if hc.Enabled {
+				if hc.Timeout >= hc.Interval {
+					return fmt.Errorf("vhost %q: health_check timeout must be < interval", name)
+				}
+				if hc.FailThreshold <= 0 {
+					return fmt.Errorf("vhost %q: health_check fail_threshold must be > 0", name)
+				}
+				if hc.PassThreshold <= 0 {
+					return fmt.Errorf("vhost %q: health_check pass_threshold must be > 0", name)
+				}
+			}
+		}
 	}
 
 	return nil
 }
+

--- a/internal/server/config/vhost.go
+++ b/internal/server/config/vhost.go
@@ -2,6 +2,9 @@ package config
 
 import (
     "time"
+
+    "tinyproxy/internal/cache"
+    "tinyproxy/internal/loadbalancer"
 )
 
 type SecurityConfig struct {
@@ -55,6 +58,8 @@ type VirtualHost struct {
         Params   map[string]string
     }
     BotProtection BotProtectionConfig
+    Cache         cache.CacheConfig
+    Upstream      loadbalancer.LBConfig
 }
 
 func NewVirtualHost() *VirtualHost {
@@ -85,7 +90,8 @@ func NewVirtualHost() *VirtualHost {
             },
         },
         MaxBodySize: 10 << 20, // 10MB default max body size
-
+        Cache:       cache.DefaultCacheConfig(),
+        Upstream:    loadbalancer.DefaultLBConfig(),
     }
     return vh
 }

--- a/internal/server/proxy/proxy.go
+++ b/internal/server/proxy/proxy.go
@@ -133,3 +133,42 @@ func (rp *ReverseProxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
  
 	p.ServeHTTP(w, r)
 }
+
+// NewSingleBackendProxy creates a reverse proxy targeting a single backend URL.
+// This is used by the load balancer path where the target is chosen at request time.
+func NewSingleBackendProxy(targetURL string) (http.Handler, error) {
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   10 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   20,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
+		ForceAttemptHTTP2:     true,
+	}
+
+	p := httputil.NewSingleHostReverseProxy(target)
+	p.Transport = transport
+	p.ErrorHandler = proxyErrorHandler
+
+	originalDirector := p.Director
+	p.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Header.Set("X-Forwarded-Host", req.Host)
+		req.Header.Set("X-Forwarded-Proto", schemeFromRequest(req))
+		if ip, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+			req.Header.Set("X-Real-IP", ip)
+		}
+	}
+
+	return p, nil
+}


### PR DESCRIPTION
This PR introduces two production-quality subsystems to tinyproxy — an HTTP response cache and an upstream load balancer — both configurable through the existing block-syntax config DSL and integrated into the VHostHandler request pipeline.

##  Changes

### 1. HTTP Response Cache (`internal/cache`)

A transparent, RFC-compliant HTTP caching layer inspired by nginx's `proxy_cache` and Varnish's design:

- **LRU eviction** with configurable max memory (default 256 MB)
- **TTL-based expiry** — honors `Cache-Control`, `Expires`, `Pragma` response headers; operator-configurable default TTL
- **Cache key** — `METHOD:HOST:PATH:QUERY` (configurable)
- **Conditional requests** — `ETag` / `Last-Modified` / `If-None-Match` / `If-Modified-Since` support (returns `304`)
- **Cache-Control aware** — respects `no-cache`, `no-store`, `private`, `max-age`, `s-maxage`
- **Bypass** — `Cache-Control: no-cache` from client, or configurable bypass header
- **Cache status header** — `X-Cache: HIT|MISS|BYPASS|EXPIRED` on every response
- **Method filtering** — only GET/HEAD are cacheable by default
- **Concurrent-safe** with `sync.RWMutex` per shard (sharded map for reduced contention)
- **Background revalidation** — stale-while-revalidate support

#### [NEW] [cache.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/cache/cache.go)

Core cache engine:
- `Cache` struct with sharded buckets, LRU eviction, TTL tracking
- `CacheEntry` struct: status code, headers, body `[]byte`, stored/expires timestamps, ETag
- `Get(key string)` → `(*CacheEntry, bool)`
- `Set(key string, entry *CacheEntry)`
- `Delete(key string)`, `Purge()` (full flush)
- `Stats()` → hit/miss/eviction counters

#### [NEW] [handler.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/cache/handler.go)

HTTP middleware:
- `CacheHandler(cfg CacheConfig, next http.Handler) http.Handler`
- Wraps `http.ResponseWriter` to capture status + headers + body
- Computes cache key, checks `Cache-Control`, serves from cache or delegates
- Sets `X-Cache` response header
- Handles conditional request negotiation (`304 Not Modified`)

#### [NEW] [config.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/cache/config.go)

```go
type CacheConfig struct {
    Enabled       bool
    MaxSize       int64         // bytes, default 256MB
    DefaultTTL    time.Duration // fallback when no Cache-Control, default 5m
    Methods       []string      // default ["GET", "HEAD"]
    BypassHeader  string        // e.g. "X-Cache-Bypass"
    StaleWhileRevalidate time.Duration
}
```

---

### 2. Upstream Load Balancer (`internal/loadbalancer`)

A multi-strategy load balancer with active health checking, modeled after nginx `upstream {}` and HAProxy backends:

#### Strategies
| Strategy | Description |
|---|---|
| `round_robin` | Default. Cycles through backends sequentially |
| `least_conn` | Routes to the backend with fewest active connections |
| `ip_hash` | Sticky sessions via consistent hashing of client IP |
| `weighted` | Weighted round-robin; heavier backends get more traffic |

#### Health Checking
- **Active checks** — periodic HTTP `GET /` (configurable path + interval + threshold)
- **Passive checks** — track consecutive failures; auto-mark backend as down
- **Circuit breaker** — if a backend fails N consecutive health checks, stop routing to it; re-probe on a backoff schedule
- **Graceful recovery** — backend must pass M consecutive checks before re-entering the rotation

#### [NEW] [balancer.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/loadbalancer/balancer.go)

Core load balancer:
- `LoadBalancer` struct: list of `Backend`, strategy, health checker
- `Backend` struct: URL, weight, alive flag, active connections counter, circuit breaker state
- `Next(clientIP string) (*Backend, error)` — picks next backend per strategy
- `MarkDone(b *Backend)` — decrements active conns (for least_conn)
- Strategy implementations as unexported types implementing a `Strategy` interface

#### [NEW] [health.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/loadbalancer/health.go)

Health checking system:
- `HealthChecker` struct with configurable interval, path, timeout, thresholds
- Background goroutine polling all backends
- Marks backends up/down based on pass/fail thresholds
- Exposes `Stats()` for observability

#### [NEW] [config.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/loadbalancer/config.go)

```go
type LBConfig struct {
    Strategy        string        // "round_robin", "least_conn", "ip_hash", "weighted"
    Backends        []BackendConfig
    HealthCheck     HealthCheckConfig
}

type BackendConfig struct {
    URL    string
    Weight int  // default 1
}

type HealthCheckConfig struct {
    Enabled     bool
    Path        string        // default "/"
    Interval    time.Duration // default 10s
    Timeout     time.Duration // default 5s
    FailThreshold int         // default 3 consecutive fails to mark down
    PassThreshold int         // default 2 consecutive passes to mark up
}
```

---

### 3. Config DSL Extensions

#### [MODIFY] [vhost.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/server/config/vhost.go)

Add fields to `VirtualHost`:
```go
Cache    cache.CacheConfig
Upstream loadbalancer.LBConfig
```

#### [MODIFY] [parser.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/server/config/parser.go)

Add parsing methods:
- `parseCache()` — parses `cache { ... }` block
- `parseUpstream()` — parses `upstream { ... }` block with nested `backend` and `health_check` sub-blocks

New config syntax:

```
vhosts {
    api.example.com {
        # Load balance across multiple backends
        upstream {
            strategy least_conn

            backend http://10.0.0.1:8080 weight 3
            backend http://10.0.0.2:8080 weight 2
            backend http://10.0.0.3:8080

            health_check {
                path /healthz
                interval 10s
                timeout 5s
                fail_threshold 3
                pass_threshold 2
            }
        }

        # Response caching
        cache {
            enabled true
            max_size 256MB
            default_ttl 5m
            stale_while_revalidate 30s
        }
    }
}
```

#### [MODIFY] [validate.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/server/config/validate.go)

Add validation rules for:
- At least one backend URL when `upstream` is configured
- Valid backend URLs
- Valid health check interval/timeout (timeout < interval)
- `max_size` > 0 when cache is enabled
- Mutually exclusive `proxy_pass` and `upstream` (upstream replaces single proxy_pass)

---

### 4. Request Pipeline Integration

#### [MODIFY] [main.go](file:///home/carlhandy/Documents/projects/tinyproxy/cmd/tinyproxy/main.go)

Update `VHostHandler`:
- On startup, initialize per-vhost `LoadBalancer` instances and `Cache` instances based on config
- Store them in maps on the handler: `caches map[string]*cache.Cache`, `balancers map[string]*loadbalancer.LoadBalancer`
- In `handleVHost()`:
  1. If `upstream` is configured, pick a backend via the load balancer instead of using `ProxyPass`
  2. Wrap the proxy handler with `CacheHandler` if caching is enabled
- On config reload (`SIGHUP`), rebuild caches and load balancers (graceful drain)

Updated request lifecycle:
```
Request → VHost Lookup → Rate Limit → Bot Detection → Security Headers →
  Cache Check (HIT → respond) →
  Compression → Load Balancer (pick backend) → Reverse Proxy → Cache Store → Response
```

#### [MODIFY] [proxy.go](file:///home/carlhandy/Documents/projects/tinyproxy/internal/server/proxy/proxy.go)

Add helper to create a single-backend reverse proxy on the fly (for load-balanced requests where the backend is chosen at dispatch time rather than config time).

---

### 5. Config File Examples

#### [MODIFY] [vhosts.conf](file:///home/carlhandy/Documents/projects/tinyproxy/config/vhosts.conf)

Add commented examples showing the new `cache` and `upstream` blocks.

---

## Verification Plan

### Automated Tests

```bash
# Unit tests for cache (hit/miss/eviction/TTL/conditional requests)
go test ./internal/cache/... -v

# Unit tests for load balancer (strategy selection, health checking, failover)
go test ./internal/loadbalancer/... -v

# Config parser tests for new blocks
go test ./internal/server/config/... -v

# Full build verification
go build ./cmd/tinyproxy/

# Vet
go vet ./...
```

### Manual Verification
- Start dev server with a config that has `upstream` with multiple backends → verify requests distribute
- Verify `X-Cache: HIT/MISS` headers appear on cacheable responses
- Kill a backend process → verify health checker marks it down and traffic routes to remaining backends
- Test cache bypass via `Cache-Control: no-cache` header


